### PR TITLE
V2.3.1 client deprecate eof flag

### DIFF
--- a/include/ma_common.h
+++ b/include/ma_common.h
@@ -23,6 +23,7 @@
 #include <mysql.h>
 #include <hash.h>
 
+#define MAX_PACKET_LENGTH (256L*256L*256L-1)
 
 typedef struct st_mariadb_db_driver
 {

--- a/include/my_stmt.h
+++ b/include/my_stmt.h
@@ -215,7 +215,7 @@ typedef struct st_mysql_perm_bind {
 } MYSQL_PS_CONVERSION;
 
 extern MYSQL_PS_CONVERSION mysql_ps_fetch_functions[MYSQL_TYPE_GEOMETRY + 1];
-unsigned long net_safe_read(MYSQL *mysql);
+unsigned long net_safe_read(MYSQL *mysql, my_bool *is_data_packet);
 void mysql_init_ps_subsystem(void);
 unsigned long net_field_length(unsigned char **packet);
 int simple_command(MYSQL *mysql,enum enum_server_command command, const char *arg,

--- a/include/mysql_com.h
+++ b/include/mysql_com.h
@@ -151,6 +151,7 @@ enum enum_server_command
 #define CLIENT_PLUGIN_AUTH       (1UL << 19)
 #define CLIENT_CONNECT_ATTRS     (1UL << 20)
 #define CLIENT_SESSION_TRACKING  (1UL << 23)
+#define CLIENT_DEPRECATE_EOF     (1UL << 24)
 #define CLIENT_PROGRESS          (1UL << 29) /* client supports progress indicator */
 #define CLIENT_SSL_VERIFY_SERVER_CERT (1UL << 30)
 #define CLIENT_REMEMBER_OPTIONS  (1UL << 31)
@@ -178,6 +179,7 @@ enum enum_server_command
                                  CLIENT_REMEMBER_OPTIONS |\
                                  CLIENT_PLUGIN_AUTH |\
                                  CLIENT_SESSION_TRACKING |\
+                                 CLIENT_DEPRECATE_EOF |\
                                  CLIENT_CONNECT_ATTRS)
 
 #define CLIENT_CAPABILITIES	(CLIENT_LONG_PASSWORD |\
@@ -189,6 +191,7 @@ enum enum_server_command
                                  CLIENT_PROTOCOL_41 |\
                                  CLIENT_PLUGIN_AUTH |\
                                  CLIENT_SESSION_TRACKING |\
+                                 CLIENT_DEPRECATE_EOF |\
                                  CLIENT_CONNECT_ATTRS)
 
 #define CLIENT_DEFAULT_FLAGS ((CLIENT_SUPPORTED_FLAGS & ~CLIENT_COMPRESS)\

--- a/libmariadb/my_auth.c
+++ b/libmariadb/my_auth.c
@@ -466,7 +466,7 @@ static int client_mpvio_read_packet(struct st_plugin_vio *mpv, uchar **buf)
   }
 
   /* otherwise read the data */
-  pkt_len= net_safe_read(mysql);
+  pkt_len= net_safe_read(mysql, NULL);
   mpvio->last_read_packet_len= pkt_len;
   *buf= mysql->net.read_pos;
 
@@ -662,7 +662,7 @@ int run_plugin_auth(MYSQL *mysql, char *data, uint data_len,
 
   /* read the OK packet (or use the cached value in mysql->net.read_pos */
   if (res == CR_OK)
-    pkt_length= net_safe_read(mysql);
+    pkt_length= net_safe_read(mysql, NULL);
   else /* res == CR_OK_HANDSHAKE_COMPLETE */
     pkt_length= mpvio.last_read_packet_len;
 
@@ -716,7 +716,7 @@ int run_plugin_auth(MYSQL *mysql, char *data, uint data_len,
     if (res != CR_OK_HANDSHAKE_COMPLETE)
     {
       /* Read what server thinks about out new auth message report */
-      if (net_safe_read(mysql) == packet_error)
+      if (net_safe_read(mysql, NULL) == packet_error)
       {
         if (mysql->net.last_errno == CR_SERVER_LOST)
           my_set_error(mysql, CR_SERVER_LOST, SQLSTATE_UNKNOWN,

--- a/libmariadb/my_stmt.c
+++ b/libmariadb/my_stmt.c
@@ -256,16 +256,18 @@ int mthd_stmt_read_all_rows(MYSQL_STMT *stmt)
         /* sace status info */
         p++;
         stmt->upsert_status.warning_count= stmt->mysql->warning_count= uint2korr(p);
-        p+=2;
-        if (stmt->mysql->server_status & SERVER_PS_OUT_PARAMS)
-        {
-          stmt->upsert_status.server_status= stmt->mysql->server_status= uint2korr(p)
-            | SERVER_PS_OUT_PARAMS
-            | (stmt->mysql->server_status & SERVER_MORE_RESULTS_EXIST);
-        }
-        else
-          stmt->upsert_status.warning_count= stmt->mysql->server_status= uint2korr(p);
       }
+      p+=2;
+
+      if (stmt->mysql->server_status & SERVER_PS_OUT_PARAMS)
+      {
+        stmt->upsert_status.server_status= stmt->mysql->server_status= uint2korr(p)
+          | SERVER_PS_OUT_PARAMS
+          | (stmt->mysql->server_status & SERVER_MORE_RESULTS_EXIST);
+      }
+      else
+        stmt->upsert_status.server_status= uint2korr(p);
+
       stmt->result_cursor= result->data; 
       DBUG_RETURN(0);
     }
@@ -1531,7 +1533,6 @@ int STDCALL mysql_stmt_execute(MYSQL_STMT *stmt)
   request= (char *)mysql_stmt_execute_generate_request(stmt, &request_len);
   DBUG_PRINT("info",("request_len=%ld", request_len));
 
-  // TODO: here is where read read the stmt result
   ret= test(simple_command(mysql, MYSQL_COM_STMT_EXECUTE, request, request_len, 1, stmt) || 
       (mysql && mysql->methods->db_read_stmt_result && mysql->methods->db_read_stmt_result(mysql)));
   if (request)

--- a/libmariadb/my_stmt.c
+++ b/libmariadb/my_stmt.c
@@ -114,6 +114,10 @@ my_bool mthd_supported_buffer_type(enum enum_field_types type)
 
 static my_bool madb_reset_stmt(MYSQL_STMT *stmt, unsigned int flags);
 
+extern MYSQL_FIELD *mthd_my_read_metadata(MYSQL *mysql, ulong field_count, uint field);
+extern MYSQL_FIELD *mthd_my_read_metadata_ex(MYSQL *mysql, MEM_ROOT *alloc,
+                                     ulong field_count, uint field);
+extern int ma_read_ok_packet(MYSQL *mysql, uchar *pos, ulong length);
 static int stmt_unbuffered_eof(MYSQL_STMT *stmt, uchar **row)
 {
   return MYSQL_NO_DATA;
@@ -122,10 +126,11 @@ static int stmt_unbuffered_eof(MYSQL_STMT *stmt, uchar **row)
 static int stmt_unbuffered_fetch(MYSQL_STMT *stmt, uchar **row)
 {
   ulong pkt_len;
+  my_bool is_data_packet;
 
   DBUG_ENTER("stmt_unbuffered_fetch");
 
-  pkt_len= net_safe_read(stmt->mysql);
+  pkt_len= net_safe_read(stmt->mysql, &is_data_packet);
   DBUG_PRINT("info",("packet_length= %ld",pkt_len));
 
   if (pkt_len == packet_error)
@@ -134,8 +139,10 @@ static int stmt_unbuffered_fetch(MYSQL_STMT *stmt, uchar **row)
     DBUG_RETURN(1);
   }
 
-  if (stmt->mysql->net.read_pos[0] == 254)
+  if (stmt->mysql->net.read_pos[0] != 0 && !is_data_packet)
   {
+    if (stmt->mysql->server_capabilities & CLIENT_DEPRECATE_EOF)
+      ma_read_ok_packet(stmt->mysql, stmt->mysql->net.read_pos + 1, pkt_len);
     *row = NULL;
     stmt->fetch_row_func= stmt_unbuffered_eof;
     DBUG_RETURN(MYSQL_NO_DATA);
@@ -167,15 +174,16 @@ int mthd_stmt_read_all_rows(MYSQL_STMT *stmt)
   MYSQL_ROWS *current, **pprevious;
   ulong packet_len;
   unsigned char *p;
+  my_bool is_data_packet;
 
   DBUG_ENTER("stmt_read_all_rows");
 
   pprevious= &result->data;
 
-  while ((packet_len = net_safe_read(stmt->mysql)) != packet_error)
+  while ((packet_len = net_safe_read(stmt->mysql, &is_data_packet)) != packet_error)
   {
     p= stmt->mysql->net.read_pos;
-    if (packet_len > 7 || p[0] != 254)
+    if (p[0] == 0 || is_data_packet)
     {
       /* allocate space for rows */
       if (!(current= (MYSQL_ROWS *)alloc_root(&result->alloc, sizeof(MYSQL_ROWS) + packet_len)))
@@ -241,11 +249,23 @@ int mthd_stmt_read_all_rows(MYSQL_STMT *stmt)
     } else  /* end of stream */
     {
       *pprevious= 0;
-      /* sace status info */
-      p++;
-      stmt->upsert_status.warning_count= stmt->mysql->warning_count= uint2korr(p);
-      p+=2;
-      stmt->mysql->server_status= uint2korr(p);
+      if (stmt->mysql->server_capabilities & CLIENT_DEPRECATE_EOF && !is_data_packet)
+        ma_read_ok_packet(stmt->mysql, p + 1, packet_len);
+      else
+      {
+        /* sace status info */
+        p++;
+        stmt->upsert_status.warning_count= stmt->mysql->warning_count= uint2korr(p);
+        p+=2;
+        if (stmt->mysql->server_status & SERVER_PS_OUT_PARAMS)
+        {
+          stmt->upsert_status.server_status= stmt->mysql->server_status= uint2korr(p)
+            | SERVER_PS_OUT_PARAMS
+            | (stmt->mysql->server_status & SERVER_MORE_RESULTS_EXIST);
+        }
+        else
+          stmt->upsert_status.warning_count= stmt->mysql->server_status= uint2korr(p);
+      }
       stmt->result_cursor= result->data; 
       DBUG_RETURN(0);
     }
@@ -299,10 +319,35 @@ static int stmt_cursor_fetch(MYSQL_STMT *stmt, uchar **row)
 
 void mthd_stmt_flush_unbuffered(MYSQL_STMT *stmt)
 {
+  MYSQL *mysql = stmt->mysql;
   ulong packet_len;
-  while ((packet_len = net_safe_read(stmt->mysql)) != packet_error)
-    if (packet_len < 8 && stmt->mysql->net.read_pos[0] == 254)
-      return;
+  my_bool is_data_packet;
+  uchar *pos;
+
+  int in_resultset= stmt->state > MYSQL_STMT_EXECUTED &&
+    stmt->state < MYSQL_STMT_FETCH_DONE;
+
+  while ((packet_len = net_safe_read(stmt->mysql, &is_data_packet)) != packet_error)
+  {
+    pos= mysql->net.read_pos;
+    if (stmt->mysql->server_capabilities & CLIENT_DEPRECATE_EOF)
+    {
+      if ((!in_resultset && *pos == 0) || // OK Packet
+          (*pos != 0 && !is_data_packet)) // EOF Packet
+      {
+        ma_read_ok_packet(mysql, pos + 1, packet_len);
+        goto end;
+      }
+      in_resultset = 1;
+    }
+    else
+    {
+      if (packet_len < 8 && stmt->mysql->net.read_pos[0] == 254)
+        return;
+    }
+  }
+end:
+  stmt->state= MYSQL_STMT_FETCH_DONE;
 }
 
 int mthd_stmt_fetch_to_bind(MYSQL_STMT *stmt, unsigned char *row)
@@ -1166,7 +1211,7 @@ my_bool mthd_stmt_read_prepare_response(MYSQL_STMT *stmt)
 
   DBUG_ENTER("read_prepare_response");
 
-  if ((packet_length= net_safe_read(stmt->mysql)) == packet_error)
+  if ((packet_length= net_safe_read(stmt->mysql, NULL)) == packet_error)
     DBUG_RETURN(1);
 
   DBUG_PRINT("info",("packet_length= %ld",packet_length));
@@ -1194,29 +1239,24 @@ my_bool mthd_stmt_read_prepare_response(MYSQL_STMT *stmt)
 
 my_bool mthd_stmt_get_param_metadata(MYSQL_STMT *stmt)
 {
-  MYSQL_DATA *result;
-
   DBUG_ENTER("stmt_get_param_metadata");
 
-  if (!(result= stmt->mysql->methods->db_read_rows(stmt->mysql, (MYSQL_FIELD *)0, 7)))
+  if (!(mthd_my_read_metadata(stmt->mysql, stmt->param_count, 7)))
     DBUG_RETURN(1);
 
-  free_rows(result);
+  /* free memory allocated by mthd_my_read_metadata() for parameters data */
+  free_root(&stmt->mysql->field_alloc, MYF(0));
   DBUG_RETURN(0);
 }
 
 my_bool mthd_stmt_get_result_metadata(MYSQL_STMT *stmt)
 {
-  MYSQL_DATA *result;
   MEM_ROOT *fields_alloc_root= &((MADB_STMT_EXTENSION *)stmt->extension)->fields_alloc_root;
   DBUG_ENTER("stmt_read_result_metadata");
 
-  if (!(result= stmt->mysql->methods->db_read_rows(stmt->mysql, (MYSQL_FIELD *)0, 7)))
+  if (!(stmt->fields= mthd_my_read_metadata_ex(stmt->mysql, fields_alloc_root, stmt->field_count, 7)))
     DBUG_RETURN(1);
-  if (!(stmt->fields= unpack_fields(result,fields_alloc_root,
-          stmt->field_count, 0,
-          stmt->mysql->server_capabilities & CLIENT_LONG_FLAG)))
-    DBUG_RETURN(1); 
+
   DBUG_RETURN(0);
 }
 
@@ -1445,7 +1485,8 @@ int STDCALL mysql_stmt_execute(MYSQL_STMT *stmt)
   char *request;
   int ret;
   size_t request_len= 0;
-
+  my_bool is_data_packet;
+  size_t pkt_len;
 
   DBUG_ENTER("mysql_stmt_execute");
 
@@ -1490,6 +1531,7 @@ int STDCALL mysql_stmt_execute(MYSQL_STMT *stmt)
   request= (char *)mysql_stmt_execute_generate_request(stmt, &request_len);
   DBUG_PRINT("info",("request_len=%ld", request_len));
 
+  // TODO: here is where read read the stmt result
   ret= test(simple_command(mysql, MYSQL_COM_STMT_EXECUTE, request, request_len, 1, stmt) || 
       (mysql && mysql->methods->db_read_stmt_result && mysql->methods->db_read_stmt_result(mysql)));
   if (request)
@@ -1498,6 +1540,48 @@ int STDCALL mysql_stmt_execute(MYSQL_STMT *stmt)
   /* if a reconnect occured, our connection handle is invalid */
   if (!stmt->mysql)
     DBUG_RETURN(1);
+
+  if ((mysql->server_capabilities & CLIENT_DEPRECATE_EOF))
+  {
+    if (mysql->server_status & SERVER_STATUS_CURSOR_EXISTS)
+      mysql->server_status&= ~SERVER_STATUS_CURSOR_EXISTS;
+
+    /*
+      After having read the query result, we need to make sure that the client
+      does not end up into a hang waiting for the server to send a packet.
+      If the CURSOR_TYPE_READ_ONLY flag is set, we would want to perform the
+      additional packet read mainly for prepared statements involving SELECT
+      queries. For SELECT queries, the result format would either be
+      <Metadata><OK> or <Metadata><rows><OK>. We would have read the metadata
+      by now and have the field_count populated. The check for field_count will
+      help determine if we can expect an additional packet from the server.
+    */
+    if (!ret && (stmt->flags & CURSOR_TYPE_READ_ONLY) &&
+        mysql->field_count != 0)
+    {
+      /*
+        server can now respond with a cursor - then the respond will be
+        <Metadata><OK> or with binary rows result set <Metadata><row(s)><OK>.
+        The former can be the case when the prepared statement is a procedure
+        invocation, ie. call(). There also other cases. When server responds
+        with <OK> (cursor) packet we read it and get the server status. In case
+        it responds with binary row we add it to the binary rows result set
+        (the reset of the result set will be read in prepare_to_fetch_result).
+      */
+
+      if ((pkt_len= net_safe_read(mysql, &is_data_packet)) == packet_error)
+        return(1);
+
+      if (is_data_packet)
+      {
+        // TODO: <metadata><row(s)><OK> not supported right now
+        // needs a refactoring of reading binary data code
+        return 1;
+      }
+      else
+        ma_read_ok_packet(mysql, mysql->net.read_pos + 1, pkt_len);
+    }
+  }
 
   /* update affected rows, also if an error occured */
   stmt->upsert_status.affected_rows= stmt->mysql->affected_rows;

--- a/libmariadb/net.c
+++ b/libmariadb/net.c
@@ -31,11 +31,10 @@
 #include <signal.h>
 #include <errno.h>
 #include <sys/types.h>
+#include <ma_common.h>
 #ifndef _WIN32
 #include <poll.h>
 #endif
-
-#define MAX_PACKET_LENGTH (256L*256L*256L-1)
 
 /* net_buffer_length and max_allowed_packet are defined in mysql.h
    See bug conc-57

--- a/unittest/libmariadb/ps_bugs.c
+++ b/unittest/libmariadb/ps_bugs.c
@@ -3894,6 +3894,10 @@ static int test_conc141(MYSQL *mysql)
 
   rc= mysql_stmt_execute(stmt);
   check_stmt_rc(rc, stmt);
+
+  rc= mysql_stmt_free_result(stmt);
+  check_stmt_rc(rc, stmt);
+
   /* skip first result */
   rc= mysql_stmt_next_result(stmt);
   FAIL_IF(rc==-1, "No more results and error expected");

--- a/unittest/libmariadb/ps_new.c
+++ b/unittest/libmariadb/ps_new.c
@@ -105,6 +105,10 @@ static int test_multi_result(MYSQL *mysql)
  
   FAIL_IF(int_data[0] != 10 || int_data[1] != 20 || int_data[2] != 30,
           "expected 10 20 30"); 
+
+  rc= mysql_stmt_free_result(stmt); // must call before next mysql_stmt_next_result
+  check_stmt_rc(rc, stmt);
+
   rc= mysql_stmt_next_result(stmt);
   check_stmt_rc(rc, stmt);
   rc= mysql_stmt_bind_result(stmt, rs_bind);

--- a/unittest/libmariadb/session_track.c
+++ b/unittest/libmariadb/session_track.c
@@ -1,5 +1,26 @@
 #include "my_test.h"
 
+static my_bool has_session_tracking(MYSQL *mysql);
+static void display_session_tracking(MYSQL *mysql);
+
+#define check_no_session_tracking(m) \
+if (has_session_tracking(m)) \
+{ \
+  diag("Session tracking found in %s line %d", __FILE__, __LINE__); \
+  return FAIL; \
+}
+
+#define check_must_have_session_tracking(m) \
+if (!has_session_tracking(m)) \
+{ \
+  diag("Session tracking not found in %s line %d", __FILE__, __LINE__); \
+  return FAIL; \
+} \
+else \
+{ \
+  display_session_tracking(m); \
+}
+
 static int test_system_variables(MYSQL *mysql)
 {
   int rc;
@@ -78,8 +99,123 @@ static int test_system_variables(MYSQL *mysql)
   return OK;
 }
 
+static int test_session_track_with_proctor(MYSQL *mysql)
+{
+  int rc;
+
+  rc = mysql_query(mysql, "SELECT EXISTS"
+      "(SELECT * FROM INFORMATION_SCHEMA.PLUGINS where PLUGIN_NAME='MYSQL_PROCTOR')");
+  check_mysql_rc(rc, mysql);
+  MYSQL_RES *result = mysql_store_result(mysql);
+  MYSQL_ROW row = mysql_fetch_row(result);
+  if (row[0][0] == '0')
+  {
+    diag("MYSQL_PROCTOR plugin not found");
+    return SKIP;
+  }
+
+  rc = mysql_query(mysql, "drop table if exists t1");
+  check_mysql_rc(rc, mysql);
+  check_must_have_session_tracking(mysql);
+
+  rc = mysql_query(mysql, "create table t1 (c1 INT) Engine=InnoDB");
+  check_mysql_rc(rc, mysql);
+  check_must_have_session_tracking(mysql);
+
+  rc = mysql_query(mysql, "insert into t1 values (1)");
+  check_mysql_rc(rc, mysql);
+  check_must_have_session_tracking(mysql);
+
+  const char *data;
+  size_t len;
+
+  FAIL_IF(mysql_session_track_get_first(mysql, SESSION_TRACK_SYSTEM_VARIABLES, &data, &len),
+      "Expected to find SESSION_TRACK_SYSTEM_VARIABLES");
+  FAIL_IF(strncmp("mysql_proctor_innodb_performance_data", data, len),
+      "Expected to find 'mysql_proctor_innodb_performance_data'");
+  mysql_session_track_get_next(mysql, SESSION_TRACK_SYSTEM_VARIABLES, &data, &len);
+  FAIL_IF(len < 1, "Expected proctor value to be greater than 1 in length");
+
+  // make a backup of data 
+  char *data1;
+  size_t len1;
+  data1 = (char*)malloc(len + 1);
+  memcpy(data1, data, len);
+  data1[len] = 0;
+  len1 = len;
+
+
+  diag("select * from t1");
+  rc = mysql_query(mysql, "select * from t1");
+  check_mysql_rc(rc, mysql);
+  mysql_store_result(mysql);
+  check_must_have_session_tracking(mysql);
+
+  FAIL_IF(mysql_session_track_get_first(mysql, SESSION_TRACK_SYSTEM_VARIABLES, &data, &len),
+      "Expected to find SESSION_TRACK_SYSTEM_VARIABLES");
+  FAIL_IF(strncmp("mysql_proctor_innodb_performance_data", data, len),
+      "Expected to find 'mysql_proctor_innodb_performance_data'");
+  mysql_session_track_get_next(mysql, SESSION_TRACK_SYSTEM_VARIABLES, &data, &len);
+  FAIL_IF(len < 1, "Expected proctor value to be greater than 1 in length");
+
+  FAIL_IF(!strncmp(data, data1, MIN(len, len1)), "Expected proctor values to be different for the last two queries");
+
+  free(data1);
+
+  diag("drop table if exists t1");
+  rc = mysql_query(mysql, "drop table if exists t1");
+  check_mysql_rc(rc, mysql);
+  check_must_have_session_tracking(mysql);
+
+  return OK;
+}
+
+static my_bool has_session_tracking(MYSQL *mysql)
+{
+  my_bool found = FALSE;
+  enum enum_session_state_type type;
+  for (type = SESSION_TRACK_BEGIN; type <= SESSION_TRACK_END; type++)
+  {
+    const char *data;
+    size_t length;
+
+    if (mysql_session_track_get_first(mysql, type, &data, &length) == 0)
+    {
+      found = TRUE;
+      break;
+    }
+  }
+  return found;
+}
+
+static void display_session_tracking(MYSQL *mysql)
+{
+  enum enum_session_state_type type;
+  for (type = SESSION_TRACK_BEGIN; type <= SESSION_TRACK_END; type++)
+  {
+    const char *data;
+    size_t length;
+
+    if (mysql_session_track_get_first(mysql, type, &data, &length) == 0)
+    {
+      /* print info type and initial data */
+      printf("Type=%d:\n", type);
+      printf("mysql_session_track_get_first(): length=%d; data=%*.*s\n",
+          (int) length, (int) length, (int) length, data);
+
+      /* check for more data */
+      while (mysql_session_track_get_next(mysql, type, &data, &length) == 0)
+      {
+        printf("mysql_session_track_get_next(): length=%d; data=%*.*s\n",
+            (int) length, (int) length, (int) length, data);
+      }
+    }
+  }
+}
+
 struct my_tests_st my_tests[] = {
   {"test_system_variables", test_system_variables, TEST_CONNECTION_NEW, 0,  NULL,  NULL},
+  {"test_session_track_with_proctor", test_session_track_with_proctor, TEST_CONNECTION_DEFAULT, 0, NULL, NULL},
   {NULL, NULL, 0, 0, NULL, NULL}
 };
 


### PR DESCRIPTION
**Note**

This PR brings the CLIENT_DEPRECATE_EOF flag changes on mariadb-3x branch to 2x branch so it can be integrated with ProxySQL 1.4.

PR for mariadb-3x branch [here](https://github.com/mariadb-corporation/mariadb-connector-c/pull/131)

### PR Description

mariadb-connector-c client now sends CLIENT_DEPRECATE_EOF flag to the server.

There are some major changes on how the server responds. Mainly the way packets are sent back from server changes which are documented in https://dev.mysql.com/worklog/task/?id=7766

I will try to add as much comment on the code changes as possible. For most of the changes, I looked into the worklog, looked into how packets are sent by the server and existing mysql client's source code.