### PR TITLE
CLIENT_DEPRECATE_EOF for v3.1.4 branch

### DIFF
--- a/include/ma_common.h
+++ b/include/ma_common.h
@@ -23,6 +23,8 @@
 #include <mysql.h>
 #include <ma_hash.h>
 
+#define MAX_PACKET_LENGTH (256L*256L*256L-1)
+
 enum enum_multi_status {
   COM_MULTI_OFF= 0,
   COM_MULTI_CANCEL,

--- a/include/mariadb_com.h
+++ b/include/mariadb_com.h
@@ -160,6 +160,7 @@ enum enum_server_command
 #define CLIENT_CONNECT_ATTRS     (1UL << 20)
 #define CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS (1UL << 22)
 #define CLIENT_SESSION_TRACKING  (1UL << 23)
+#define CLIENT_DEPRECATE_EOF     (1UL << 24)
 #define CLIENT_PROGRESS          (1UL << 29) /* client supports progress indicator */
 #define CLIENT_PROGRESS_OBSOLETE  CLIENT_PROGRESS 
 #define CLIENT_SSL_VERIFY_SERVER_CERT (1UL << 30)
@@ -201,6 +202,7 @@ enum enum_server_command
                                  CLIENT_REMEMBER_OPTIONS |\
                                  CLIENT_PLUGIN_AUTH |\
                                  CLIENT_SESSION_TRACKING |\
+                                 CLIENT_DEPRECATE_EOF |\
                                  CLIENT_CONNECT_ATTRS)
 
 #define CLIENT_CAPABILITIES	(CLIENT_MYSQL | \
@@ -212,6 +214,7 @@ enum enum_server_command
                                  CLIENT_PROTOCOL_41 |\
                                  CLIENT_PLUGIN_AUTH |\
                                  CLIENT_SESSION_TRACKING |\
+                                 CLIENT_DEPRECATE_EOF |\
                                  CLIENT_CONNECT_ATTRS)
 
 #define CLIENT_DEFAULT_FLAGS ((CLIENT_SUPPORTED_FLAGS & ~CLIENT_COMPRESS)\

--- a/include/mariadb_stmt.h
+++ b/include/mariadb_stmt.h
@@ -255,7 +255,7 @@ typedef struct st_mysql_perm_bind {
 } MYSQL_PS_CONVERSION;
 
 extern MYSQL_PS_CONVERSION mysql_ps_fetch_functions[MYSQL_TYPE_GEOMETRY + 1];
-unsigned long ma_net_safe_read(MYSQL *mysql);
+unsigned long ma_net_safe_read(MYSQL *mysql, my_bool *is_data_packet);
 void mysql_init_ps_subsystem(void);
 unsigned long net_field_length(unsigned char **packet);
 int ma_simple_command(MYSQL *mysql,enum enum_server_command command, const char *arg,

--- a/libmariadb/ma_net.c
+++ b/libmariadb/ma_net.c
@@ -39,8 +39,6 @@
 #include <poll.h>
 #endif
 
-#define MAX_PACKET_LENGTH (256L*256L*256L-1)
-
 /* net_buffer_length and max_allowed_packet are defined in mysql.h
    See bug conc-57
  */

--- a/libmariadb/mariadb_lib.c
+++ b/libmariadb/mariadb_lib.c
@@ -136,6 +136,7 @@ struct st_mariadb_methods MARIADB_DEFAULT_METHODS;
 #define IS_CONNHDLR_ACTIVE(mysql)\
   ((mysql)->extension && (mysql)->extension->conn_hdlr)
 
+int ma_read_ok_packet(MYSQL *mysql, uchar *pos, ulong length);
 static void end_server(MYSQL *mysql);
 static void mysql_close_memory(MYSQL *mysql);
 void read_user_name(char *name);
@@ -182,10 +183,13 @@ void net_get_error(char *buf, size_t buf_len,
 *****************************************************************************/
 
 ulong
-ma_net_safe_read(MYSQL *mysql)
+ma_net_safe_read(MYSQL *mysql, my_bool *is_data_packet)
 {
   NET *net= &mysql->net;
   ulong len=0;
+
+  if (is_data_packet)
+    *is_data_packet= FALSE;
 
 restart:
   if (net->pvio != 0)
@@ -242,6 +246,38 @@ restart:
     mysql->server_status&= ~SERVER_MORE_RESULTS_EXIST;
 
     return(packet_error);
+  }
+  else
+  {
+    /*
+      Now we have a data packet, unless it is OK packet starting with
+      0xFE - we detect that case below.
+    */
+    if (is_data_packet)
+      *is_data_packet= TRUE;
+    /*
+       For a packet starting with 0xFE detect if it is OK packet or a
+       huge data packet. Note that old servers do not send OK packets
+       starting with 0xFE.
+    */
+    if ((mysql->server_capabilities & CLIENT_DEPRECATE_EOF) &&
+        (net->read_pos[0] == 254))
+    {
+      /* detect huge data packet */
+      if (len > MAX_PACKET_LENGTH)
+        return len;
+      /* otherwise we have OK packet starting with 0xFE */
+      if (is_data_packet)
+        *is_data_packet= FALSE;
+      return len;
+    }
+    /* for old client detect EOF packet */
+    if (!(mysql->server_capabilities & CLIENT_DEPRECATE_EOF) &&
+        (net->read_pos[0] == 254) && (len < 8))
+    {
+      if (is_data_packet)
+        *is_data_packet= FALSE;
+    }
   }
   return len;
 }
@@ -416,7 +452,7 @@ mthd_my_send_cmd(MYSQL *mysql,enum enum_server_command command, const char *arg,
 
   if (!skipp_check)
   {
-    result= ((mysql->packet_length=ma_net_safe_read(mysql)) == packet_error ?
+    result= ((mysql->packet_length=ma_net_safe_read(mysql, NULL)) == packet_error ?
 	     1 : 0);
   }
  end:
@@ -556,12 +592,13 @@ end_server(MYSQL *mysql)
 void mthd_my_skip_result(MYSQL *mysql)
 {
   ulong pkt_len;
+  my_bool is_data_packet;
 
   do {
-    pkt_len= ma_net_safe_read(mysql);
+    pkt_len= ma_net_safe_read(mysql, &is_data_packet);
     if (pkt_len == packet_error)
       break;
-  } while (pkt_len > 8 || mysql->net.read_pos[0] != 254);
+  } while (mysql->net.read_pos[0] == 0 || is_data_packet);
   return;
 }
 
@@ -769,68 +806,97 @@ static size_t rset_field_offsets[]= {
   OFFSET(MYSQL_FIELD, org_name_length)
 };
 
+
+/**
+  Read field metadata from field descriptor and store it in MYSQL_FIELD structure.
+  String values in MYSQL_FIELD are allocated in a given allocator root.
+
+  @param mysql          connection handle
+  @param alloc          memory allocator root
+  @param default_value  flag telling if default values should be read from
+                        descriptor
+  @param server_capabilities  protocol capability flags which determine format of
+                              the descriptor
+  @param row            field descriptor
+  @param field          address of MYSQL_FIELD structure to store metadata in.
+
+  @returns 0 on success.
+*/
+
+int
+unpack_field(MA_MEM_ROOT *alloc, my_bool default_value,
+             MYSQL_ROWS *row, MYSQL_FIELD *field)
+{
+  unsigned int i, field_count= sizeof(rset_field_offsets)/sizeof(size_t)/2;
+  char    *p;
+
+  for (i=0; i < field_count; i++)
+  {
+    switch(row->data[i][0]) {
+      case 0:
+        *(char **)(((char *)field) + rset_field_offsets[i*2])= ma_strdup_root(alloc, "");
+        *(unsigned int *)(((char *)field) + rset_field_offsets[i*2+1])= 0;
+        break;
+      default:
+        *(char **)(((char *)field) + rset_field_offsets[i*2])=
+          ma_strdup_root(alloc, (char *)row->data[i]);
+        *(unsigned int *)(((char *)field) + rset_field_offsets[i*2+1])=
+          (uint)(row->data[i+1] - row->data[i] - 1);
+        break;
+    }
+  }
+
+  p= (char *)row->data[6];
+  /* filler */
+  field->charsetnr= uint2korr(p);
+  p+= 2;
+  field->length= (uint) uint4korr(p);
+  p+= 4;
+  field->type=   (enum enum_field_types)uint1korr(p);
+  p++;
+  field->flags= uint2korr(p);
+  p+= 2;
+  field->decimals= (uint) p[0];
+  p++;
+
+  /* filler */
+  p+= 2;
+
+  if (INTERNAL_NUM_FIELD(field))
+    field->flags|= NUM_FLAG;
+
+  /* This is used by deprecated function mysql_list_fields only,
+     however the reported length is not correct, so we always zero it */
+  if (default_value && row->data[7])
+    field->def=ma_strdup_root(alloc,(char*) row->data[7]);
+  else
+    field->def=0;
+  field->def_length= 0;
+  field->max_length= 0;
+
+  return 0;
+}
+
 MYSQL_FIELD *
 unpack_fields(MYSQL_DATA *data,MA_MEM_ROOT *alloc,uint fields,
 	      my_bool default_value, my_bool long_flag_protocol __attribute__((unused)))
 {
   MYSQL_ROWS	*row;
   MYSQL_FIELD	*field,*result;
-  char    *p;
-  unsigned int i, field_count= sizeof(rset_field_offsets)/sizeof(size_t)/2;
 
   field=result=(MYSQL_FIELD*) ma_alloc_root(alloc,sizeof(MYSQL_FIELD)*fields);
   if (!result)
     return(0);
+  memset(field, 0, sizeof(MYSQL_FIELD)*fields);
 
   for (row=data->data; row ; row = row->next,field++)
   {
+    /* fields count may be wrong */
     if (field >= result + fields)
       goto error;
 
-    for (i=0; i < field_count; i++)
-    {
-      switch(row->data[i][0]) {
-      case 0:
-       *(char **)(((char *)field) + rset_field_offsets[i*2])= ma_strdup_root(alloc, "");
-       *(unsigned int *)(((char *)field) + rset_field_offsets[i*2+1])= 0;
-       break;
-     default:
-       *(char **)(((char *)field) + rset_field_offsets[i*2])=
-         ma_strdup_root(alloc, (char *)row->data[i]);
-       *(unsigned int *)(((char *)field) + rset_field_offsets[i*2+1])=
-         (uint)(row->data[i+1] - row->data[i] - 1);
-       break;
-      }
-    }
-
-    p= (char *)row->data[6];
-    /* filler */
-    field->charsetnr= uint2korr(p);
-    p+= 2;
-    field->length= (uint) uint4korr(p);
-    p+= 4;
-    field->type=   (enum enum_field_types)uint1korr(p);
-    p++;
-    field->flags= uint2korr(p);
-    p+= 2;
-    field->decimals= (uint) p[0];
-    p++;
-
-    /* filler */
-    p+= 2;
-
-    if (INTERNAL_NUM_FIELD(field))
-      field->flags|= NUM_FLAG;
-
-    /* This is used by deprecated function mysql_list_fields only,
-       however the reported length is not correct, so we always zero it */
-    if (default_value && row->data[7])
-      field->def=ma_strdup_root(alloc,(char*) row->data[7]);
-    else
-      field->def=0;
-    field->def_length= 0;
-
-    field->max_length= 0;
+    if (unpack_field(alloc, default_value, row, field) != 0)
+      goto error;
   }
   if (field < result + fields)
     goto error;
@@ -856,8 +922,9 @@ MYSQL_DATA *mthd_my_read_rows(MYSQL *mysql,MYSQL_FIELD *mysql_fields,
   MYSQL_DATA *result;
   MYSQL_ROWS **prev_ptr,*cur;
   NET *net = &mysql->net;
+  my_bool is_data_packet;
 
-  if ((pkt_len= ma_net_safe_read(mysql)) == packet_error)
+  if ((pkt_len= ma_net_safe_read(mysql, &is_data_packet)) == packet_error)
     return(0);
   if (!(result=(MYSQL_DATA*) calloc(1, sizeof(MYSQL_DATA))))
   {
@@ -870,7 +937,7 @@ MYSQL_DATA *mthd_my_read_rows(MYSQL *mysql,MYSQL_FIELD *mysql_fields,
   result->rows=0;
   result->fields=fields;
 
-  while (*(cp=net->read_pos) != 254 || pkt_len >= 8)
+  while (*(cp=net->read_pos) == 0 || is_data_packet)
   {
     result->rows++;
     if (!(cur= (MYSQL_ROWS*) ma_alloc_root(&result->alloc,
@@ -913,7 +980,7 @@ MYSQL_DATA *mthd_my_read_rows(MYSQL *mysql,MYSQL_FIELD *mysql_fields,
       }
     }
     cur->data[field]=to;			/* End of last field */
-    if ((pkt_len=ma_net_safe_read(mysql)) == packet_error)
+    if ((pkt_len=ma_net_safe_read(mysql, &is_data_packet)) == packet_error)
     {
       free_rows(result);
       return(0);
@@ -923,10 +990,14 @@ MYSQL_DATA *mthd_my_read_rows(MYSQL *mysql,MYSQL_FIELD *mysql_fields,
   /* save status */
   if (pkt_len > 1)
   {
-    cp++;
-    mysql->warning_count= uint2korr(cp);
-    cp+= 2;
-    mysql->server_status= uint2korr(cp);
+    // We know this is the OK packet
+    if (mysql->server_capabilities & CLIENT_DEPRECATE_EOF)
+      ma_read_ok_packet(mysql, cp + 1, pkt_len);
+    else
+    {
+      mysql->warning_count= uint2korr(cp + 1);
+      mysql->server_status= uint2korr(cp + 3);
+    }
   }
   return(result);
 }
@@ -943,18 +1014,26 @@ int mthd_my_read_one_row(MYSQL *mysql,uint fields,MYSQL_ROW row, ulong *lengths)
   uint field;
   ulong pkt_len,len;
   uchar *pos,*prev_pos, *end_pos;
+  my_bool is_data_packet;
+  NET *net= &mysql->net;
 
-  if ((pkt_len=(uint) ma_net_safe_read(mysql)) == packet_error)
+  if ((pkt_len=(uint) ma_net_safe_read(mysql, &is_data_packet)) == packet_error)
     return -1;
 
-  if (pkt_len <= 8 && mysql->net.read_pos[0] == 254)
+  if (net->read_pos[0] != 0 && !is_data_packet)
   {
-    mysql->warning_count= uint2korr(mysql->net.read_pos + 1);
-    mysql->server_status= uint2korr(mysql->net.read_pos + 3);
-    return 1;				/* End of data */
+    if (mysql->server_capabilities & CLIENT_DEPRECATE_EOF)
+      ma_read_ok_packet(mysql, net->read_pos + 1, pkt_len);
+    else
+    {
+      mysql->warning_count= uint2korr(net->read_pos + 1);
+      mysql->server_status= uint2korr(net->read_pos + 3);
+    }
+    return 1; /* End of data */
   }
+
   prev_pos= 0;				/* allowed to write at packet[-1] */
-  pos=mysql->net.read_pos;
+  pos=net->read_pos;
   end_pos=pos+pkt_len;
   for (field=0 ; field < fields ; field++)
   {
@@ -967,8 +1046,8 @@ int mthd_my_read_one_row(MYSQL *mysql,uint fields,MYSQL_ROW row, ulong *lengths)
     {
       if (len > (ulong) (end_pos - pos) || pos > end_pos)
       {
-        mysql->net.last_errno=CR_UNKNOWN_ERROR;
-        strncpy(mysql->net.last_error,ER(mysql->net.last_errno),
+        net->last_errno=CR_UNKNOWN_ERROR;
+        strncpy(net->last_error,ER(net->last_errno),
                 MYSQL_ERRMSG_SIZE - 1);
         return -1;
       }
@@ -983,6 +1062,73 @@ int mthd_my_read_one_row(MYSQL *mysql,uint fields,MYSQL_ROW row, ulong *lengths)
   row[field]=(char*) prev_pos+1;		/* End of last field */
   *prev_pos=0;					/* Terminate last field */
   return 0;
+}
+
+/**
+ * If CLIENT_DEPRECATE_EOF isn't supported by the server, the response looked like
+ * <FieldCount><Metadata><EOF><ResultSet * n><EOF>.
+ *
+ * Otherwise, the response looks like <FieldCount><Metadata><ResultSet * n><EOF>.
+ * The number of metadata to look for is already available in FieldCount
+ * therefore first EOF is not necessary.
+ *
+ * Therefore this method is introduced to just read packet metadata 
+ * and is called by both mthd_my_read_query_result and mthd_stmt_read_prepare_response
+ */
+MYSQL_FIELD *mthd_my_read_metadata_ex(MYSQL *mysql, MA_MEM_ROOT *alloc,
+                                     ulong field_count, uint field)
+{
+  ulong *len;
+  uint  f;
+  uchar *pos;
+  MYSQL_FIELD *fields, *result;
+  MYSQL_ROWS data;
+  NET *net = &mysql->net;
+
+  len= (ulong*) ma_alloc_root(alloc, sizeof(ulong)*field);
+  fields= result= (MYSQL_FIELD *) ma_alloc_root(alloc,
+      sizeof(MYSQL_FIELD)*field_count);
+
+  if (!result)
+  {
+    SET_CLIENT_ERROR(mysql, CR_OUT_OF_MEMORY, SQLSTATE_UNKNOWN, 0);
+    return(0);
+  }
+
+  data.data= (MYSQL_ROW) ma_alloc_root(alloc, sizeof(char *)*(field+1));
+  memset(data.data, 0, sizeof(char *)*(field+1));
+
+  /*
+     In this below loop we read each column info as 1 single row
+     and save it in mysql->fields array
+     */
+  for (f=0 ; f < field_count ; ++f)
+  {
+    if(mthd_my_read_one_row(mysql, field, data.data, len) == -1)
+      return NULL;
+    if(unpack_field(alloc, 0, &data, fields++))
+      return NULL;
+  }
+  if (!(mysql->server_capabilities & CLIENT_DEPRECATE_EOF))
+  {
+    if (packet_error == ma_net_safe_read(mysql, NULL))
+      return 0;
+
+    pos= net->read_pos;
+    if (*pos == 254)
+    {
+      mysql->warning_count= uint2korr(pos + 1);
+      mysql->server_status= uint2korr(pos + 3);
+    }
+  }
+
+  return result;
+}
+
+MYSQL_FIELD *mthd_my_read_metadata(MYSQL *mysql, ulong field_count, uint field)
+{
+  return mthd_my_read_metadata_ex(mysql, &mysql->field_alloc,
+                                  field_count, field);
 }
 
 /****************************************************************************
@@ -1366,7 +1512,7 @@ MYSQL *mthd_my_real_connect(MYSQL *mysql, const char *host, const char *user,
     goto error;
   }
  */
-  if ((pkt_length=ma_net_safe_read(mysql)) == packet_error)
+  if ((pkt_length=ma_net_safe_read(mysql, NULL)) == packet_error)
   {
     if (mysql->net.last_errno == CR_SERVER_LOST)
       my_set_error(mysql, CR_SERVER_LOST, SQLSTATE_UNKNOWN,
@@ -2128,14 +2274,13 @@ int mthd_my_read_query_result(MYSQL *mysql)
 {
   uchar *pos;
   ulong field_count;
-  MYSQL_DATA *fields;
   ulong length;
   my_bool can_local_infile= (mysql->options.extension) && (mysql->extension->auto_local_infile != WAIT_FOR_QUERY);
 
   if (mysql->options.extension && mysql->extension->auto_local_infile == ACCEPT_FILE_REQUEST)
     mysql->extension->auto_local_infile= WAIT_FOR_QUERY;
 
-  if (!mysql || (length = ma_net_safe_read(mysql)) == packet_error)
+  if ((length = ma_net_safe_read(mysql, NULL)) == packet_error)
   {
     return(1);
   }
@@ -2148,7 +2293,7 @@ get_info:
   {
     int error=mysql_handle_local_infile(mysql, (char *)pos, can_local_infile);
 
-    if ((length=ma_net_safe_read(mysql)) == packet_error || error)
+    if ((length=ma_net_safe_read(mysql, NULL)) == packet_error || error)
       return(-1);
     goto get_info;				/* Get info packet */
   }
@@ -2156,13 +2301,11 @@ get_info:
     mysql->server_status|= SERVER_STATUS_IN_TRANS;
 
   mysql->extra_info= net_field_length_ll(&pos); /* Maybe number of rec */
-  if (!(fields=mysql->methods->db_read_rows(mysql,(MYSQL_FIELD*) 0,8)))
-    return(-1);
-  if (!(mysql->fields=unpack_fields(fields,&mysql->field_alloc,
-				    (uint) field_count,1,
-				    (my_bool) test(mysql->server_capabilities &
-						   CLIENT_LONG_FLAG))))
-    return(-1);
+  if (!(mysql->fields=mthd_my_read_metadata(mysql, field_count, 7)))
+  {
+    ma_free_root(&mysql->field_alloc,MYF(0));
+    return(1);
+  }
   mysql->status=MYSQL_STATUS_GET_RESULT;
   mysql->field_count=field_count;
   return(0);
@@ -2507,22 +2650,17 @@ mysql_list_fields(MYSQL *mysql, const char *table, const char *wild)
 MYSQL_RES * STDCALL
 mysql_list_processes(MYSQL *mysql)
 {
-  MYSQL_DATA *fields;
   uint field_count;
   uchar *pos;
 
-  LINT_INIT(fields);
   if (ma_simple_command(mysql, COM_PROCESS_INFO,0,0,0,0))
     return(NULL);
   free_old_query(mysql);
   pos=(uchar*) mysql->net.read_pos;
   field_count=(uint) net_field_length(&pos);
-  if (!(fields = mysql->methods->db_read_rows(mysql,(MYSQL_FIELD*) 0,5)))
+  if (!(mysql->fields=mthd_my_read_metadata(mysql, field_count, 7)))
     return(NULL);
-  if (!(mysql->fields=unpack_fields(fields,&mysql->field_alloc,field_count,0,
-				    (my_bool) test(mysql->server_capabilities &
-						   CLIENT_LONG_FLAG))))
-    return(NULL);
+
   mysql->status=MYSQL_STATUS_GET_RESULT;
   mysql->field_count=field_count;
   return(mysql_store_result(mysql));
@@ -3963,7 +4101,7 @@ mysql_debug(const char *debug __attribute__((unused)))
 *********************************************************************/
 ulong STDCALL mysql_net_read_packet(MYSQL *mysql)
 {
-  return ma_net_safe_read(mysql);
+  return ma_net_safe_read(mysql, NULL);
 }
 
 ulong STDCALL mysql_net_field_length(uchar **packet)
@@ -4152,41 +4290,41 @@ struct st_mariadb_api MARIADB_API=
  */
 struct st_mariadb_methods MARIADB_DEFAULT_METHODS = {
   /* open a connection */
-  mthd_my_real_connect,
+  mthd_my_real_connect, // db_connect
   /* close connection */
-  mysql_close_slow_part,
+  mysql_close_slow_part, // db_close
   /* send command to server */
-  mthd_my_send_cmd,
+  mthd_my_send_cmd, // db_command
   /* skip result set */
-  mthd_my_skip_result,
+  mthd_my_skip_result, // db_skip_result
   /* read response packet */
-  mthd_my_read_query_result,
+  mthd_my_read_query_result, // db_read_query_result
   /* read all rows from a result set */
-  mthd_my_read_rows,
+  mthd_my_read_rows, // db_read_rows
   /* read one/next row */
-  mthd_my_read_one_row,
+  mthd_my_read_one_row, // db_read_one_row
   /* check if datatype is supported */
-  mthd_supported_buffer_type,
+  mthd_supported_buffer_type, // db_supported_buffer_type
   /* read response packet from prepare */
-  mthd_stmt_read_prepare_response,
+  mthd_stmt_read_prepare_response, // db_read_prepare_response
   /* read response from stmt execute */
-  mthd_my_read_query_result,
+  mthd_my_read_query_result, // db_read_stmt_result
   /* get result set metadata for a prepared statement */
-  mthd_stmt_get_result_metadata,
+  mthd_stmt_get_result_metadata, // db_stmt_get_result_metadata
   /* get param metadata for a prepared statement */
-  mthd_stmt_get_param_metadata,
+  mthd_stmt_get_param_metadata, // db_stmt_get_param_metadata
   /* read all rows (buffered) */
-  mthd_stmt_read_all_rows,
+  mthd_stmt_read_all_rows, // db_stmt_read_all_rows
   /* fetch one row (unbuffered) */
-  mthd_stmt_fetch_row,
+  mthd_stmt_fetch_row, // db_stmt_fetch
   /* store values in bind buffer */
-  mthd_stmt_fetch_to_bind,
+  mthd_stmt_fetch_to_bind, // db_stmt_fetch_to_bind
   /* skip unbuffered stmt result */
-  mthd_stmt_flush_unbuffered,
+  mthd_stmt_flush_unbuffered, // db_stmt_flush_unbuffered
   /* set error */
-  my_set_error,
+  my_set_error, // set_error
   /* invalidate statements */
-  ma_invalidate_stmts,
+  ma_invalidate_stmts, // invalidate_stmts
   /* API functions */
-  &MARIADB_API
+  &MARIADB_API // api
 };

--- a/libmariadb/mariadb_rpl.c
+++ b/libmariadb/mariadb_rpl.c
@@ -122,7 +122,7 @@ MARIADB_RPL_EVENT * STDCALL mariadb_rpl_fetch(MARIADB_RPL *rpl, MARIADB_RPL_EVEN
     return 0;
 
   while (1) {
-    unsigned long pkt_len= ma_net_safe_read(rpl->mysql);
+    unsigned long pkt_len= ma_net_safe_read(rpl->mysql, NULL);
 
     if (pkt_len == packet_error)
     {

--- a/libmariadb/mariadb_stmt.c
+++ b/libmariadb/mariadb_stmt.c
@@ -145,6 +145,10 @@ my_bool mthd_supported_buffer_type(enum enum_field_types type)
 
 static my_bool madb_reset_stmt(MYSQL_STMT *stmt, unsigned int flags);
 static my_bool mysql_stmt_internal_reset(MYSQL_STMT *stmt, my_bool is_close);
+extern MYSQL_FIELD *mthd_my_read_metadata(MYSQL *mysql, ulong field_count, uint field);
+extern MYSQL_FIELD *mthd_my_read_metadata_ex(MYSQL *mysql, MA_MEM_ROOT *alloc,
+                                     ulong field_count, uint field);
+extern int ma_read_ok_packet(MYSQL *mysql, uchar *pos, ulong length);
 static int stmt_unbuffered_eof(MYSQL_STMT *stmt __attribute__((unused)),
                                uchar **row __attribute__((unused)))
 {
@@ -154,8 +158,12 @@ static int stmt_unbuffered_eof(MYSQL_STMT *stmt __attribute__((unused)),
 static int stmt_unbuffered_fetch(MYSQL_STMT *stmt, uchar **row)
 {
   ulong pkt_len;
+  my_bool is_data_packet;
+  MYSQL *mysql;
 
-  pkt_len= ma_net_safe_read(stmt->mysql);
+  mysql = stmt->mysql;
+
+  pkt_len= ma_net_safe_read(mysql, &is_data_packet);
 
   if (pkt_len == packet_error)
   {
@@ -163,14 +171,17 @@ static int stmt_unbuffered_fetch(MYSQL_STMT *stmt, uchar **row)
     return(1);
   }
 
-  if (stmt->mysql->net.read_pos[0] == 254)
+  if (mysql->net.read_pos[0] != 0 && !is_data_packet)
   {
+    /* in case of new client read the OK packet */
+    if (mysql->server_capabilities & CLIENT_DEPRECATE_EOF)
+      ma_read_ok_packet(mysql, mysql->net.read_pos + 1, pkt_len);
     *row = NULL;
     stmt->fetch_row_func= stmt_unbuffered_eof;
     return(MYSQL_NO_DATA);
   }
   else
-    *row = stmt->mysql->net.read_pos;
+    *row = mysql->net.read_pos;
   stmt->result.rows++;
   return(0);
 }
@@ -196,13 +207,14 @@ int mthd_stmt_read_all_rows(MYSQL_STMT *stmt)
   MYSQL_ROWS *current, **pprevious;
   ulong packet_len;
   unsigned char *p;
+  my_bool is_data_packet;
 
   pprevious= &result->data;
 
-  while ((packet_len = ma_net_safe_read(stmt->mysql)) != packet_error)
+  while ((packet_len = ma_net_safe_read(stmt->mysql, &is_data_packet)) != packet_error)
   {
     p= stmt->mysql->net.read_pos;
-    if (packet_len > 7 || p[0] != 254)
+    if (p[0] == 0 || is_data_packet)
     {
       /* allocate space for rows */
       if (!(current= (MYSQL_ROWS *)ma_alloc_root(&result->alloc, sizeof(MYSQL_ROWS) + packet_len)))
@@ -276,11 +288,34 @@ int mthd_stmt_read_all_rows(MYSQL_STMT *stmt)
     } else  /* end of stream */
     {
       *pprevious= 0;
-      /* sace status info */
-      p++;
-      stmt->upsert_status.warning_count= stmt->mysql->warning_count= uint2korr(p);
-      p+=2;
-      stmt->upsert_status.server_status= stmt->mysql->server_status= uint2korr(p);
+      /* save status info */
+      if (stmt->mysql->server_capabilities & CLIENT_DEPRECATE_EOF && !is_data_packet)
+        ma_read_ok_packet(stmt->mysql, p + 1, packet_len);
+      else
+        stmt->upsert_status.warning_count= stmt->mysql->warning_count= uint2korr(p + 1);
+
+      /*
+        OUT parameters result sets has SERVER_PS_OUT_PARAMS and
+        SERVER_MORE_RESULTS_EXISTS flags in first EOF_Packet only.
+        Last EOF_Packet of OUT parameters result sets have no
+        SERVER_MORE_RESULTS_EXISTS flag as described here:
+        http://dev.mysql.com/doc/internals/en/stored-procedures.html#out-parameter-set
+        Following code reads last EOF_Packet of result set and can clear
+        those flags in server_status if we don't preserve them.
+        Without SERVER_MORE_RESULTS_EXISTS flag mysql_stmt_next_result fails
+        to read OK_Packet after OUT parameters result set.
+        So we need to preserve SERVER_MORE_RESULTS_EXISTS flag for OUT
+        parameters result set.
+      */
+      if (stmt->mysql->server_status & SERVER_PS_OUT_PARAMS)
+      {
+        stmt->upsert_status.server_status= stmt->mysql->server_status= uint2korr(p + 3)
+          | SERVER_PS_OUT_PARAMS
+          | (stmt->mysql->server_status & SERVER_MORE_RESULTS_EXIST);
+      }
+      else
+        stmt->upsert_status.server_status= stmt->mysql->server_status= uint2korr(p + 3);
+
       stmt->result_cursor= result->data;
       return(0);
     }
@@ -336,31 +371,58 @@ static int stmt_cursor_fetch(MYSQL_STMT *stmt, uchar **row)
 /* flush one result set */
 void mthd_stmt_flush_unbuffered(MYSQL_STMT *stmt)
 {
+  MYSQL *mysql = stmt->mysql;
   ulong packet_len;
+  my_bool is_data_packet;
+  uchar *pos;
+
   int in_resultset= stmt->state > MYSQL_STMT_EXECUTED &&
                     stmt->state < MYSQL_STMT_FETCH_DONE;
-  while ((packet_len = ma_net_safe_read(stmt->mysql)) != packet_error)
+  while ((packet_len = ma_net_safe_read(mysql, &is_data_packet)) != packet_error)
   {
-    uchar *pos= stmt->mysql->net.read_pos;
-    if (!in_resultset && *pos == 0) /* OK */
+    pos= mysql->net.read_pos;
+    if (stmt->mysql->server_capabilities & CLIENT_DEPRECATE_EOF)
     {
-      pos++;
-      net_field_length(&pos);
-      net_field_length(&pos);
-      stmt->mysql->server_status= uint2korr(pos);
-      goto end;
-    }
-    if (packet_len < 8 && *pos == 254) /* EOF */
-    {
-      if (mariadb_connection(stmt->mysql))
+      if (!in_resultset && *pos == 0) /* actual OK packet with 0 */
       {
-        stmt->mysql->server_status= uint2korr(pos + 3);
-        if (in_resultset)
-          goto end;
-        in_resultset= 1;
-      }
-      else
+        ma_read_ok_packet(mysql, pos + 1, packet_len);
         goto end;
+      }
+
+      // so we do not check for OK pkt with 0 next time in the loop
+      // packet with first byte = 0 can only happen as the first packet
+      in_resultset = 1;
+
+      if (*pos != 0 && !is_data_packet)
+      {
+        ma_read_ok_packet(mysql, pos + 1, packet_len);
+        goto end;
+      }
+    }
+    else
+    {
+      if (!in_resultset && *pos == 0) /* OK */
+      {
+        pos++;
+        net_field_length(&pos);
+        net_field_length(&pos);
+        mysql->server_status= uint2korr(pos);
+        goto end;
+      }
+      if (packet_len < 8 && *pos == 254) /* EOF */
+      {
+        if (mariadb_connection(mysql))
+        {
+          mysql->server_status= uint2korr(pos + 3);
+          if (in_resultset)
+            goto end;
+          in_resultset= 1;
+        }
+        else
+        {
+          goto end;
+        }
+      }
     }
   }
 end:
@@ -1554,7 +1616,7 @@ my_bool mthd_stmt_read_prepare_response(MYSQL_STMT *stmt)
   ulong packet_length;
   uchar *p;
 
-  if ((packet_length= ma_net_safe_read(stmt->mysql)) == packet_error)
+  if ((packet_length= ma_net_safe_read(stmt->mysql, NULL)) == packet_error)
     return(1);
 
   p= (uchar *)stmt->mysql->net.read_pos;
@@ -1581,26 +1643,20 @@ my_bool mthd_stmt_read_prepare_response(MYSQL_STMT *stmt)
 
 my_bool mthd_stmt_get_param_metadata(MYSQL_STMT *stmt)
 {
-  MYSQL_DATA *result;
-
-  if (!(result= stmt->mysql->methods->db_read_rows(stmt->mysql, (MYSQL_FIELD *)0, 7)))
+  if (!(mthd_my_read_metadata(stmt->mysql, stmt->param_count, 7)))
     return(1);
 
-  free_rows(result);
+  /* free memory allocated by mthd_my_read_metadata() for parameters data */
+  ma_free_root(&stmt->mysql->field_alloc, MYF(0));
   return(0);
 }
 
 my_bool mthd_stmt_get_result_metadata(MYSQL_STMT *stmt)
 {
-  MYSQL_DATA *result;
   MA_MEM_ROOT *fields_ma_alloc_root= &((MADB_STMT_EXTENSION *)stmt->extension)->fields_ma_alloc_root;
+  if (!(stmt->fields= mthd_my_read_metadata_ex(stmt->mysql, fields_ma_alloc_root, stmt->field_count, 7)))
+    return(1);
 
-  if (!(result= stmt->mysql->methods->db_read_rows(stmt->mysql, (MYSQL_FIELD *)0, 7)))
-    return(1);
-  if (!(stmt->fields= unpack_fields(result,fields_ma_alloc_root,
-          stmt->field_count, 0,
-          stmt->mysql->server_capabilities & CLIENT_LONG_FLAG)))
-    return(1);
   return(0);
 }
 
@@ -1669,8 +1725,7 @@ int STDCALL mysql_stmt_prepare(MYSQL_STMT *stmt, const char *query, unsigned lon
       mysql->methods->db_read_prepare_response(stmt))
     goto fail;
 
-  /* metadata not supported yet */
-
+  /* metadata not supported yet, read and discard */
   if (stmt->param_count &&
       stmt->mysql->methods->db_stmt_get_param_metadata(stmt))
   {
@@ -1855,6 +1910,8 @@ int stmt_read_execute_response(MYSQL_STMT *stmt)
 {
   MYSQL *mysql= stmt->mysql;
   int ret;
+  size_t pkt_len;
+  my_bool is_data_packet;
 
   if (!mysql)
     return(1);
@@ -1864,6 +1921,48 @@ int stmt_read_execute_response(MYSQL_STMT *stmt)
   /* if a reconnect occurred, our connection handle is invalid */
   if (!stmt->mysql)
     return(1);
+
+  if ((mysql->server_capabilities & CLIENT_DEPRECATE_EOF))
+  {
+    if (mysql->server_status & SERVER_STATUS_CURSOR_EXISTS)
+      mysql->server_status&= ~SERVER_STATUS_CURSOR_EXISTS;
+
+    /*
+      After having read the query result, we need to make sure that the client
+      does not end up into a hang waiting for the server to send a packet.
+      If the CURSOR_TYPE_READ_ONLY flag is set, we would want to perform the
+      additional packet read mainly for prepared statements involving SELECT
+      queries. For SELECT queries, the result format would either be
+      <Metadata><OK> or <Metadata><rows><OK>. We would have read the metadata
+      by now and have the field_count populated. The check for field_count will
+      help determine if we can expect an additional packet from the server.
+    */
+    if (!ret && (stmt->flags & CURSOR_TYPE_READ_ONLY) &&
+        mysql->field_count != 0)
+    {
+      /*
+        server can now respond with a cursor - then the respond will be
+        <Metadata><OK> or with binary rows result set <Metadata><row(s)><OK>.
+        The former can be the case when the prepared statement is a procedure
+        invocation, ie. call(). There also other cases. When server responds
+        with <OK> (cursor) packet we read it and get the server status. In case
+        it responds with binary row we add it to the binary rows result set
+        (the reset of the result set will be read in prepare_to_fetch_result).
+      */
+
+      if ((pkt_len= ma_net_safe_read(mysql, &is_data_packet)) == packet_error)
+        return(1);
+
+      if (is_data_packet)
+      {
+        // TODO: <metadata><row(s)><OK> not supported right now
+        // needs a refactoring of reading binary data code
+        return 1;
+      }
+      else
+        ma_read_ok_packet(mysql, mysql->net.read_pos + 1, pkt_len);
+    }
+  }
 
   /* update affected rows, also if an error occurred */
   stmt->upsert_status.affected_rows= stmt->mysql->affected_rows;

--- a/plugins/auth/my_auth.c
+++ b/plugins/auth/my_auth.c
@@ -394,7 +394,7 @@ static int client_mpvio_read_packet(struct st_plugin_vio *mpv, uchar **buf)
   }
 
   /* otherwise read the data */
-  if ((pkt_len= ma_net_safe_read(mysql)) == packet_error)
+  if ((pkt_len= ma_net_safe_read(mysql, NULL)) == packet_error)
     return (int)packet_error;
 
   mpvio->last_read_packet_len= pkt_len;
@@ -612,7 +612,7 @@ retry:
 
   /* read the OK packet (or use the cached value in mysql->net.read_pos */
   if (res == CR_OK)
-    pkt_length= ma_net_safe_read(mysql);
+    pkt_length= ma_net_safe_read(mysql, NULL);
   else /* res == CR_OK_HANDSHAKE_COMPLETE or an error */
     pkt_length= mpvio.last_read_packet_len;
 

--- a/unittest/libmariadb/connection.c
+++ b/unittest/libmariadb/connection.c
@@ -1670,8 +1670,11 @@ static int test_conc392(MYSQL *mysql)
     diag("Server doesn't support session tracking (cap=%lu)", mysql->server_capabilities);
     return SKIP;
   }
-  
+
   rc= mysql_query(mysql, "set session_track_state_change=1");
+  check_mysql_rc(rc, mysql);
+
+  rc= mysql_query(mysql, "USE mysql");
   check_mysql_rc(rc, mysql);
 
   if (mysql_session_track_get_first(mysql, SESSION_TRACK_STATE_CHANGE, &data, &len))

--- a/unittest/libmariadb/ps_bugs.c
+++ b/unittest/libmariadb/ps_bugs.c
@@ -3931,6 +3931,10 @@ static int test_conc141(MYSQL *mysql)
 
   rc= mysql_stmt_execute(stmt);
   check_stmt_rc(rc, stmt);
+
+  rc= mysql_stmt_free_result(stmt);
+  check_stmt_rc(rc, stmt);
+
   /* skip first result */
   rc= mysql_stmt_next_result(stmt);
   FAIL_IF(rc==-1, "No more results and error expected");

--- a/unittest/libmariadb/ps_new.c
+++ b/unittest/libmariadb/ps_new.c
@@ -105,6 +105,10 @@ static int test_multi_result(MYSQL *mysql)
  
   FAIL_IF(int_data[0] != 10 || int_data[1] != 20 || int_data[2] != 30,
           "expected 10 20 30");
+
+  rc= mysql_stmt_free_result(stmt); // must call before next mysql_stmt_next_result
+  check_stmt_rc(rc, stmt);
+
   rc= mysql_stmt_next_result(stmt);
   check_stmt_rc(rc, stmt);
   rc= mysql_stmt_bind_result(stmt, rs_bind);
@@ -114,6 +118,9 @@ static int test_multi_result(MYSQL *mysql)
   FAIL_IF(int_data[0] != 100 || int_data[1] != 200 || int_data[2] != 300,
           "expected 100 200 300");
 
+  rc= mysql_stmt_free_result(stmt);
+  check_stmt_rc(rc, stmt);
+
   FAIL_IF(mysql_stmt_next_result(stmt) != 0, "expected more results");
   rc= mysql_stmt_bind_result(stmt, rs_bind);
 
@@ -121,6 +128,9 @@ static int test_multi_result(MYSQL *mysql)
   FAIL_IF(mysql_stmt_field_count(stmt) != 2, "expected 2 fields");
   FAIL_IF(int_data[0] != 200 || int_data[1] != 300,
           "expected 100 200 300");
+
+  rc= mysql_stmt_free_result(stmt);
+  check_stmt_rc(rc, stmt);
   
   FAIL_IF(mysql_stmt_next_result(stmt) != 0, "expected more results");
   FAIL_IF(mysql_stmt_field_count(stmt) != 0, "expected 0 fields");


### PR DESCRIPTION
This is the same as https://github.com/bibstha/mariadb-connector-c/pull/2
while #2 takes care of `3.1 branch` which is few changes ahead of 3.1.4, I modified the #2 so we can get a patch for ProxySQL which uses 3.1.4.

